### PR TITLE
Fix subject & mail address max lengths

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
               <label class="label">Email Subject:</label>
               <div class="control">
                 {{ form.email_title(class="input is-primary is-rounded",
-                placeholder="Sept. budget report", maxlength=25, spellcheck="",
+                placeholder="Sept. budget report", maxlength=80, spellcheck="",
                 autofocus="") }}
               </div>
               <p class="help">Input the subject of your email here</p>
@@ -28,7 +28,7 @@
               <label class="label">To:</label>
               <div class="control">
                 {{ form.email_address(class="input is-primary is-rounded",
-                placeholder="sabrina@example.com", maxlength=25) }}
+                placeholder="sabrina@example.com", maxlength=40) }}
               </div>
               <p class="help">Input the recipient's email address here</p>
             </div>

--- a/templates/track_list.html
+++ b/templates/track_list.html
@@ -90,7 +90,11 @@
     <a href="{{ url_for('tracking_data', utm_id=item[0]) }}">
       <div id="track-cards" class="card m-3">
         <header class="card-header">
+          {% if item[1]["MailTitle"]|length > 35 %}
+          <p class="card-header-title">{{item[1]["MailTitle"][:35]}}...</p>
+          {% else %}
           <p class="card-header-title">{{item[1]["MailTitle"]}}</p>
+          {% endif %}
         </header>
 
         <div class="card-body" style="padding: 15px">


### PR DESCRIPTION
- Closes #12 
- Set subject max length to 80 & mail address to 40
- Update tracking cards on UI
